### PR TITLE
画像パス変更

### DIFF
--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -16,14 +16,13 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from . import settings
-from django.conf.urls import static, url
+from django.conf.urls.static import static
 from django.views.static import serve
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('pls.urls')),
-    url(r'^media/(?P.*)$', serve, {'document_root': settings.MEDIA_ROOT}),
 ]
 
 #if settings.DEBUG:

--- a/templates/pls/log_in.html
+++ b/templates/pls/log_in.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="login">
     {% load static %}
-    <img class="login__logo" src="{% static "/pls_logo.png" %}" alt="PLS">
+    <img class="login__logo" src="{% static "/img/pls_logo.png" %}" alt="PLS">
     <a href="/admin">SIGN UP</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
html側は/img/...と、
urls.pyではエラーの原因となっていたであろう、url()の記述を無くしました。